### PR TITLE
Thêm PKGBUILD cho arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Với Arch Linux, cách cài đặt giống như trên AUR. Đầu tiên:
 ```sh
 cd archlinux
 ```
-Nếu muốn cài đặt bản git (mới nhất, kéo trực tiếp từ master vệ) 
+Nếu muốn cài đặt bản git (mới nhất, kéo trực tiếp từ master về) 
 ```sh 
 cp PKGBUILD-git PKGBUILD
 ``` 

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -17,7 +17,7 @@
 #
 # Maintainer: Luong Thanh Lam <ltlam93@gmail.com>
 pkgname=ibus-bamboo
-pkgver=0.3.3
+pkgver=0.3.0
 pkgrel=1
 pkgdesc='A Vietnamese IME for IBus'
 arch=(any)
@@ -25,9 +25,10 @@ license=(GPL3)
 url="https://github.com/BambooEngine/ibus-bamboo"
 depends=(ibus)
 makedepends=('go' 'libx11' 'libxtst')
-source=($pkgname-$pkgver.tar.gz)
+source=("$pkgname"::"https://github.com/BambooEngine/$pkgname/archive/v$pkgver.tar.gz")
 md5sums=('SKIP')
 options=('!strip')
+conflicts=(ibus-bamboo-git)
 
 build() {
   cd "$pkgname-$pkgver"

--- a/archlinux/PKGBUILD-git
+++ b/archlinux/PKGBUILD-git
@@ -1,0 +1,48 @@
+#
+# Bamboo - A Vietnamese Input method editor
+# Copyright (C) 2018 Luong Thanh Lam <ltlam93@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Maintainer: Luong Thanh Lam <ltlam93@gmail.com>
+pkgname=ibus-bamboo-git
+pkgver=0.3.3
+pkgrel=1
+pkgdesc='A Vietnamese IME for IBus'
+arch=(any)
+license=(GPL3)
+url="https://github.com/BambooEngine/ibus-bamboo"
+depends=(ibus)
+makedepends=('go' 'libx11' 'libxtst')
+source=("$pkgname"::git+'https://github.com/BambooEngine/ibus-bamboo.git')
+md5sums=('SKIP')
+options=('!strip')
+conflicts=(ibus-bamboo)
+
+prerare () {
+  git clone https://github.com/BambooEngine/ibus-bamboo.git
+}
+
+build() {
+  cd "$pkgname"
+
+  make
+}
+
+
+package() {
+  cd "$pkgname"
+
+  make DESTDIR="$pkgdir/" install
+}

--- a/archlinux/PKGBUILD-release
+++ b/archlinux/PKGBUILD-release
@@ -25,8 +25,8 @@ license=(GPL3)
 url="https://github.com/BambooEngine/ibus-bamboo"
 depends=(ibus)
 makedepends=('go' 'libx11' 'libxtst')
-source=("$pkgname"::"https://github.com/BambooEngine/$pkgname/archive/v$pkgver.tar.gz")
-md5sums=('SKIP')
+source=("$pkgname-$pkgver.tar.gz"::"https://github.com/BambooEngine/$pkgname/archive/v$pkgver.tar.gz")
+md5sums=('65cfce196144f1863ffcbfa6af8d38fe')
 options=('!strip')
 conflicts=(ibus-bamboo-git)
 

--- a/archlinux/PKGBUILD-release
+++ b/archlinux/PKGBUILD-release
@@ -1,0 +1,44 @@
+#
+# Bamboo - A Vietnamese Input method editor
+# Copyright (C) 2018 Luong Thanh Lam <ltlam93@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Maintainer: Luong Thanh Lam <ltlam93@gmail.com>
+pkgname=ibus-bamboo
+pkgver=0.3.0
+pkgrel=1
+pkgdesc='A Vietnamese IME for IBus'
+arch=(any)
+license=(GPL3)
+url="https://github.com/BambooEngine/ibus-bamboo"
+depends=(ibus)
+makedepends=('go' 'libx11' 'libxtst')
+source=("$pkgname"::"https://github.com/BambooEngine/$pkgname/archive/v$pkgver.tar.gz")
+md5sums=('SKIP')
+options=('!strip')
+conflicts=(ibus-bamboo-git)
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  make
+}
+
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  make DESTDIR="$pkgdir/" install
+}


### PR DESCRIPTION
Có thể chọn cài đặt bản release, hoặc cài đặt từ mã nguồn mới nhất được kéo từ git về.