### PR TITLE
Thêm tùy chọn cho phép tắt tổ hợp phím Shirt+~

### DIFF
--- a/src/ibus-bamboo/config.go
+++ b/src/ibus-bamboo/config.go
@@ -62,8 +62,9 @@ const (
 	IBautoCommitWithMouseMovement
 	IBemojiDisabled
 	IBfakeBackspaceEnabled
+	IBinputLookupTableDisabled
 	IBstdFlags = IBspellChecking | IBspellCheckingWithRules | IBautoNonVnRestore | IBddFreeStyle |
-		IBpreeditInvisibility | IBautoCommitWithMouseMovement | IBemojiDisabled
+		IBpreeditInvisibility | IBautoCommitWithMouseMovement | IBemojiDisabled | IBinputLookupTableDisabled
 )
 
 var DefaultBrowserList = []string{

--- a/src/ibus-bamboo/engine.go
+++ b/src/ibus-bamboo/engine.go
@@ -75,7 +75,7 @@ func (e *IBusBambooEngine) ProcessKeyEvent(keyVal uint32, keyCode uint32, state 
 		return false, nil
 	}
 	log.Printf("keyCode 0x%04x keyval 0x%04x | %c | %d\n", keyCode, keyVal, rune(keyVal), len(keyPressChan))
-	if keyVal == IBUS_OpenLookupTable && e.isInputModeLTOpened == false && e.wmClasses != "" {
+	if e.config.IBflags&IBinputLookupTableDisabled != 0 && keyVal == IBUS_OpenLookupTable && e.isInputModeLTOpened == false && e.wmClasses != "" {
 		e.resetBuffer()
 		e.isInputModeLTOpened = true
 		e.openLookupTable()
@@ -281,6 +281,7 @@ func (e *IBusBambooEngine) PropertyActivate(propName string, propState uint32) *
 			e.config.IBflags |= IBemojiDisabled
 		}
 	}
+
 	if propName == PropKeyStdToneStyle {
 		if propState == ibus.PROP_STATE_CHECKED {
 			e.config.Flags |= bamboo.EstdToneStyle
@@ -381,6 +382,15 @@ func (e *IBusBambooEngine) PropertyActivate(propName string, propState uint32) *
 			e.config.IBflags &= ^IBfakeBackspaceEnabled
 		}
 	}
+
+	if propName == PropKeyDisableInputLookupTable {
+		if propState == ibus.PROP_STATE_CHECKED {
+			e.config.IBflags &= ^IBinputLookupTableDisabled
+		} else {
+			e.config.IBflags |= IBinputLookupTableDisabled
+		}
+	}
+
 	var charset, foundCs = getCharsetFromPropKey(propName)
 	if foundCs && isValidCharset(charset) && propState == ibus.PROP_STATE_CHECKED {
 		e.config.OutputCharset = charset

--- a/src/ibus-bamboo/prop.go
+++ b/src/ibus-bamboo/prop.go
@@ -44,6 +44,7 @@ const (
 	PropKeyEmojiEnabled                = "emoji_enabled"
 	PropKeyBambooConfiguration         = "bamboo_configuration"
 	PropKeyFakeBackspace               = "x11_fake_backspace"
+	PropKeyDisableInputLookupTable     = "disable_input_lookup_table"
 )
 
 var runMode = ""
@@ -371,6 +372,11 @@ func GetOptionsPropListByConfig(c *Config) *ibus.PropList {
 		emojiChecked = ibus.PROP_STATE_UNCHECKED
 	}
 
+	inputLookupTableChecked := ibus.PROP_STATE_CHECKED
+	if c.IBflags&IBinputLookupTableDisabled != 0 {
+		inputLookupTableChecked = ibus.PROP_STATE_UNCHECKED
+	}
+
 	return ibus.NewPropList(
 		&ibus.Property{
 			Name:      "IBusProperty",
@@ -441,6 +447,18 @@ func GetOptionsPropListByConfig(c *Config) *ibus.PropList {
 			Sensitive: true,
 			Visible:   true,
 			State:     x11FakeBackspaceChecked,
+			Symbol:    dbus.MakeVariant(ibus.NewText("X")),
+			SubProps:  dbus.MakeVariant(*ibus.NewPropList()),
+		},
+		&ibus.Property{
+			Name:      "IBusProperty",
+			Key:       PropKeyDisableInputLookupTable,
+			Type:      ibus.PROP_TYPE_TOGGLE,
+			Label:     dbus.MakeVariant(ibus.NewText("Tắt tổ hợp phím Shirt+~")),
+			Tooltip:   dbus.MakeVariant(ibus.NewText("DisableLookupTable")),
+			Sensitive: true,
+			Visible:   true,
+			State:     inputLookupTableChecked,
 			Symbol:    dbus.MakeVariant(ibus.NewText("X")),
 			SubProps:  dbus.MakeVariant(*ibus.NewPropList()),
 		},


### PR DESCRIPTION
Tổ hợp phím **Shirt+~** được bật mặc định và chưa có tùy chọn tắt.
Mình thêm tùy chọn tắt để khi làm việc với terminal gõ ~ không gây phiền phức (phải gõ 2 lần mới hiện ~).