### PR TITLE
Makefile: don't hardcode C compiler to gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 PREFIX=/usr
+CC=cc
 
 engine_name=bamboo
 engine_gui_name=ibus-setup-Bamboo.desktop
@@ -42,8 +43,8 @@ xml:
 
 build:
 	GOPATH=$(CURDIR) GO111MODULE=off CGO_ENABLED=1 go build $(GOLDFLAGS) -o $(ibus_e_name) ibus-$(engine_name)
-	gcc -o $(keyboard_shortcut_editor) setup-ui/$(keyboard_shortcut_editor).c `pkg-config --libs --cflags gtk+-3.0`
-	gcc -rdynamic -o $(macro_editor) setup-ui/$(macro_editor).c `pkg-config --libs --cflags gtk+-3.0`
+	$(CC) -o $(keyboard_shortcut_editor) setup-ui/$(keyboard_shortcut_editor).c `pkg-config --libs --cflags gtk+-3.0`
+	$(CC) -rdynamic -o $(macro_editor) setup-ui/$(macro_editor).c `pkg-config --libs --cflags gtk+-3.0`
 
 t:
 	GOPATH=$(CURDIR) GO111MODULE=off CGO_ENABLED=1 go test ./src/ibus-bamboo/...


### PR DESCRIPTION
Honestly, it's strange that `gcc` is straight out used (instead of utilising the `CC` variable).