### PR TITLE
Replace io/ioutil to os based on new Go standard

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -21,7 +21,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,7 +37,7 @@ type EmojiOne struct {
 func loadEmojiOne(dataFile string) (*TrieNode, error) {
 	var trie = NewTrie()
 	var c = map[string]EmojiOne{}
-	var data, err = ioutil.ReadFile(dataFile)
+	var data, err = os.ReadFile(dataFile)
 	if err != nil {
 		return nil, err
 	}

--- a/mactab.go
+++ b/mactab.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -135,9 +134,9 @@ func OpenMactabFile(engineName string) {
 	efPath := getMactabFile(engineName)
 	if _, err := os.Stat(efPath); os.IsNotExist(err) {
 		sampleFile := getEngineSubFile(sampleMactabFile)
-		sample, err := ioutil.ReadFile(sampleFile)
+		sample, err := os.ReadFile(sampleFile)
 		log.Println(err)
-		ioutil.WriteFile(efPath, sample, 0644)
+		os.WriteFile(efPath, sample, 0644)
 	}
 
 	err := exec.Command("/usr/lib/ibus-bamboo/macro-editor", efPath).Start()

--- a/utils.go
+++ b/utils.go
@@ -23,7 +23,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -182,7 +181,7 @@ func loadConfig(engineName string) *Config {
 	}
 
 	setupConfigDir(engineName)
-	data, err := ioutil.ReadFile(getConfigPath(engineName))
+	data, err := os.ReadFile(getConfigPath(engineName))
 	if err == nil {
 		json.Unmarshal(data, &c)
 	}
@@ -196,7 +195,7 @@ func saveConfig(c *Config, engineName string) {
 		return
 	}
 
-	err = ioutil.WriteFile(fmt.Sprintf(configFile, getConfigDir(engineName), engineName), data, 0644)
+	err = os.WriteFile(fmt.Sprintf(configFile, getConfigDir(engineName), engineName), data, 0644)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
Sau Go 1.16 release note [này](https://go.dev/doc/go1.16#fs) thì thư viện `io/ioutil` về cơ bản chỉ là để duy trì các code cũ.

Code mới này sẽ sử dụng thư viện `os` để hợp với tiêu chuẩn mới của Go hơn.