### PR TITLE
Fix initial config

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -78,11 +78,14 @@ var DefaultBrowserList = []string{
 
 func getEngineSubFile(fileName string) string {
 	if _, err := os.Stat(fileName); err == nil {
+		// return source code data/macro.tpl.txt path
 		if absPath, err := filepath.Abs(fileName); err == nil {
 			return absPath
 		}
 	}
 
+	// return installation data/macro.tpl.txt path
+	fileName = "../../share/ibus-bamboo/" + fileName
 	return filepath.Join(filepath.Dir(os.Args[0]), fileName)
 }
 


### PR DESCRIPTION
PR này sẽ fix lỗi khởi tạo config. Căn bản nếu build và chạy binary trong thư mục mã nguồn thì sẽ không bị lỗi. Nhưng nếu chạy chương trình khi đã cài đặt nó vô hệ thống thì nó không tìm được file `macro.tpl.txt` và crash chương trình. Nếu như đã có config được khởi tạo trước đó thì chương trình sẽ không panic.

Mình cũng từng thấy lỗi này nhưng không để ý lắm, cho đến khi 1 bạn nhắn tin với mình thì mình có thể xác nhận là lỗi này có tồn tại. Lỗi này có vẻ có sau commit https://github.com/BambooEngine/ibus-bamboo/commit/ed83023d9d18a18cbc9d7abdac286bde227bd722