### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,16 @@ jobs:
           run: |
             gmake t && gmake build
 
+  Build-test-nix-flake:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+    - name: Build flake
+      run: nix build
+    - name: Use flake devShell
+      run: nix develop
+
   Releaser:
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      version = "v0.8.4";
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "ibus-bamboo";
+            inherit version;
+
+            src = ./.;
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.wrapGAppsHook3
+              pkgs.go
+            ];
+
+            buildInputs = [
+              pkgs.xorg.libXtst
+            ];
+
+            preConfigure = ''
+              export GOCACHE="$TMPDIR/go-cache"
+              sed -i "s,/usr,$out," data/bamboo.xml
+            '';
+
+            makeFlags = [
+              "PREFIX=${placeholder "out"}"
+            ];
+          };
+        }
+      );
+
+      devShells = forAllSystems (system:
+        let
+            pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.wrapGAppsHook3
+              pkgs.go
+            ];
+
+            buildInputs = [
+              pkgs.xorg.libXtst
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Nix flake sẽ mang đến
+ Người dùng NixOS muốn cài đặt từ repo chính có thể sử dụng flake trong hệ thống của họ
+ 1 số người dùng Linux nếu biết Nix nhưng không biết sử dụng package manager trong hệ thống chính có thể sử dụng Nix để lấy các gói packages cần thiết rồi build dự án

@luongthanhlam bạn nghĩ sao? Mình nghĩ mình sẽ duy trì nó.