### PR TITLE
Fix not to send unnecessary IBusAttribute

### DIFF
--- a/engine_preedit.go
+++ b/engine_preedit.go
@@ -110,9 +110,7 @@ func (e *IBusBambooEngine) updatePreedit(processedStr string) {
 		return
 	}
 
-	if e.config.IBflags&config.IBnoUnderline != 0 {
-		ibusText.AppendAttr(ibus.IBUS_ATTR_TYPE_NONE, ibus.IBUS_ATTR_UNDERLINE_SINGLE, 0, preeditLen)
-	} else {
+	if e.config.IBflags&config.IBnoUnderline == 0 {
 		ibusText.AppendAttr(ibus.IBUS_ATTR_TYPE_UNDERLINE, ibus.IBUS_ATTR_UNDERLINE_SINGLE, 0, preeditLen)
 	}
 	e.UpdatePreeditTextWithMode(ibusText, preeditLen, true, ibus.IBUS_ENGINE_PREEDIT_COMMIT)


### PR DESCRIPTION
From https://bugzilla.redhat.com/show_bug.cgi?id=2402676

When a GTK3 application is used with GTK_IM_MODULE=ibus, it outputs many warnings with ibus 1.5.33.

```
% env GTK_IM_MODULE=ibus gedit
(gedit:48286): IBUS-WARNING **: 16:44:18.447: text:fdsaf has problem to convert to RGBA format: ibus_attr_list_copy_format_to_rgba does not support attribution type 0 at 0
```