### PR TITLE
Fix data races in preeditor access across D-Bus/worker threads

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -130,15 +130,39 @@ func (e *IBusBambooEngine) FocusIn() *dbus.Error {
 
 func (e *IBusBambooEngine) FocusOut() *dbus.Error {
 	log.Print("FocusOut.")
+	if e.checkInputMode(config.PreeditIM) {
+		e.Lock()
+		e.preeditor.Reset()
+		e.resetFakeBackspace()
+		e.Unlock()
+	}
 	return nil
 }
 
 func (e *IBusBambooEngine) Reset() *dbus.Error {
 	fmt.Print("Reset.\n")
 	if e.checkInputMode(config.PreeditIM) {
+		// In PreeditIM the in-progress text is ephemeral (managed by
+		// IBus preedit), so discard it on Reset.
+		e.HidePreeditText()
+		e.HideAuxiliaryText()
+		e.Lock()
 		e.preeditor.Reset()
+		e.resetFakeBackspace()
+		e.Unlock()
 	}
-	return nil
+	// Drain any queued keystrokes so stale events from the old
+	// context don't apply to the new one.  Safe for all modes.
+	// Non-blocking: other goroutines (the worker, updatePreviousTextInBatch)
+	// also receive from keyPressChan, so a plain len()>0 + <- would block
+	// the D-Bus thread if one of them drains the last item first.
+	for {
+		select {
+		case <-keyPressChan:
+		default:
+			return nil
+		}
+	}
 }
 
 func (e *IBusBambooEngine) Enable() *dbus.Error {

--- a/engine_backspace.go
+++ b/engine_backspace.go
@@ -32,11 +32,14 @@ import (
 )
 
 const BACKSPACE_INTERVAL = 0
+const maxBackSpacePerCycle = 50
 
 func (e *IBusBambooEngine) bsProcessKeyEvent(keyVal uint32, keyCode uint32, state uint32) (bool, *dbus.Error) {
 	if isMovementKey(keyVal) {
+		e.Lock()
 		e.preeditor.Reset()
 		e.resetFakeBackspace()
+		e.Unlock()
 		e.isSurroundingTextReady = true
 		return false, nil
 	}
@@ -44,12 +47,14 @@ func (e *IBusBambooEngine) bsProcessKeyEvent(keyVal uint32, keyCode uint32, stat
 	if e.config.IBflags&config.IBmacroEnabled == 0 && len(keyPressChan) == 0 && e.getRawKeyLen() == 0 && !inKeyList(e.preeditor.GetInputMethod().AppendingKeys, keyRune) {
 		e.updateLastKeyWithShift(keyVal, state)
 		if e.preeditor.CanProcessKey(keyRune) && isValidState(state) {
+			e.Lock()
 			e.isFirstTimeSendingBS = true
 			if state&IBusLockMask != 0 {
 				keyRune = e.toUpper(keyRune)
 			}
 			e.preeditor.ProcessKey(keyRune, bamboo.VietnameseMode)
 			e.bsCommitText([]rune(e.getPreeditString()))
+			e.Unlock()
 			return true, nil
 		}
 		return false, nil
@@ -64,25 +69,31 @@ func (e *IBusBambooEngine) bsProcessKeyEvent(keyVal uint32, keyCode uint32, stat
 					return false, nil
 				} else {
 					sleep()
+					e.Lock()
 					if e.getRawKeyLen() > 0 {
 						if e.shouldFallbackToEnglish(true) {
 							e.preeditor.RestoreLastWord(false)
 						}
 						e.preeditor.RemoveLastChar(false)
 					}
+					e.Unlock()
 				}
 				return false, nil
 			}
 			if keyVal == IBusTab {
 				sleep()
+				e.Lock()
 				if ok, _ := e.getMacroText(); !ok {
 					e.preeditor.Reset()
+					e.Unlock()
 					return false, nil
 				}
+				e.Unlock()
 			}
 			isValidKey := isValidState(state) && e.isValidKeyVal(keyVal)
 			if !isValidKey {
 				sleep()
+				// keyPressHandler takes its own lock
 				return e.keyPressHandler(keyVal, keyCode, state), nil
 			}
 		}
@@ -91,6 +102,7 @@ func (e *IBusBambooEngine) bsProcessKeyEvent(keyVal uint32, keyCode uint32, stat
 		keyPressChan <- [3]uint32{keyVal, keyCode, state}
 		return true, nil
 	} else {
+		// keyPressHandler takes its own lock
 		return e.keyPressHandler(keyVal, keyCode, state), nil
 	}
 }
@@ -104,6 +116,8 @@ func (e *IBusBambooEngine) keyPressForwardHandler(keyVal, keyCode, state uint32)
 
 func (e *IBusBambooEngine) keyPressHandler(keyVal, keyCode, state uint32) bool {
 	// log.Printf(">>Backspace:ProcessKeyEvent >  %c | keyCode 0x%04x keyVal 0x%04x | %d\n", rune(keyVal), keyCode, keyVal, len(keyPressChan))
+	e.Lock()
+	defer e.Unlock()
 	defer e.updateLastKeyWithShift(keyVal, state)
 	if e.keyPressDelay > 0 {
 		time.Sleep(time.Duration(e.keyPressDelay) * time.Millisecond)
@@ -265,6 +279,14 @@ func (e *IBusBambooEngine) getOffsetRunes(newText, oldText string) ([]rune, int)
 }
 
 func (e *IBusBambooEngine) SendBackSpace(n int) {
+	// Guard: clamp to prevent runaway backspaces from a desync.
+	if n <= 0 {
+		return
+	}
+	if n > maxBackSpacePerCycle {
+		log.Printf("WARNING: SendBackSpace(%d) clamped to %d\n", n, maxBackSpacePerCycle)
+		n = maxBackSpacePerCycle
+	}
 	// Gtk/Qt apps have a serious sync issue with fake backspaces
 	// and normal string committing, so we'll not commit right now
 	// but delay until all the sent backspaces got processed.
@@ -321,6 +343,9 @@ func (e *IBusBambooEngine) SendBackSpace(n int) {
 	} else {
 		fmt.Println("There's something wrong with wmClasses")
 	}
+	// Reset fake-backspace counter after each send cycle so a dropped
+	// synthetic backspace can't leave a permanent offset.
+	e.resetFakeBackspace()
 }
 
 func (e *IBusBambooEngine) resetFakeBackspace() {

--- a/engine_test.go
+++ b/engine_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"ibus-bamboo/config"
+	"sync"
 	"testing"
 
 	"github.com/BambooEngine/bamboo-core"
@@ -301,4 +302,243 @@ func assertEngine(t testing.TB, tc testCase, assertFn func(testing.TB, *fakeEngi
 		}
 	}
 	assertFn(t, fe, e)
+}
+
+func TestResetClearsBufferInPreeditIM(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.PreeditIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	for _, ch := range "tooi" {
+		e.preeditor.ProcessKey(ch, bamboo.VietnameseMode)
+	}
+	if e.getRawKeyLen() == 0 {
+		t.Fatal("Buffer should not be empty before Reset")
+	}
+
+	e.Reset()
+
+	if e.getRawKeyLen() != 0 {
+		t.Errorf("After Reset() in PreeditIM, rawKeyLen should be 0, got %d", e.getRawKeyLen())
+	}
+}
+
+func TestResetPreservesBufferInBackspaceModes(t *testing.T) {
+	for _, inputMode := range []int{config.SurroundingTextIM, config.BackspaceForwardingIM, config.ForwardAsCommitIM, config.XTestFakeKeyEventIM} {
+		t.Run(config.ImLookupTable[inputMode], func(t *testing.T) {
+			fe := NewFakeEngine()
+			cfg := config.DefaultCfg()
+			cfg.DefaultInputMode = inputMode
+			inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+			e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+			for _, ch := range "tooi" {
+				e.preeditor.ProcessKey(ch, bamboo.VietnameseMode)
+			}
+			if e.getRawKeyLen() == 0 {
+				t.Fatal("Buffer should not be empty before Reset")
+			}
+
+			// In backspace modes, Reset() must NOT clear the buffer
+			// because Chrome/apps call Reset() aggressively between
+			// keystrokes — clearing would break multi-keystroke words.
+			e.Reset()
+
+			if e.getRawKeyLen() == 0 {
+				t.Errorf("After Reset() in %s, buffer should be preserved", config.ImLookupTable[inputMode])
+			}
+		})
+	}
+}
+
+func TestResetDrainsKeyPressChan(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	// Enqueue some fake keystrokes
+	keyPressChan <- [3]uint32{uint32('a'), uint32('a'), 0}
+	keyPressChan <- [3]uint32{uint32('b'), uint32('b'), 0}
+
+	if len(keyPressChan) != 2 {
+		t.Fatalf("Expected 2 queued keys, got %d", len(keyPressChan))
+	}
+
+	e.Reset()
+
+	if len(keyPressChan) != 0 {
+		t.Errorf("After Reset(), keyPressChan should be drained, got %d remaining", len(keyPressChan))
+	}
+}
+
+func TestFocusInPreservesBufferInBackspaceMode(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	// First FocusIn sets wmClasses to the current WM class
+	e.FocusIn()
+
+	// Type some Vietnamese text
+	for _, ch := range "tooi" {
+		e.preeditor.ProcessKey(ch, bamboo.VietnameseMode)
+	}
+	if e.getRawKeyLen() == 0 {
+		t.Fatal("Buffer should not be empty before second FocusIn")
+	}
+
+	// Second FocusIn with same WM class should NOT reset buffer
+	// (apps fire FocusIn mid-typing for tooltips, autocomplete, etc.)
+	e.FocusIn()
+
+	if e.getRawKeyLen() == 0 {
+		t.Errorf("After FocusIn() in SurroundingTextIM with same WM class, buffer should be preserved")
+	}
+}
+
+func TestFocusOutResetsBufferInPreeditIM(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.PreeditIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	for _, ch := range "tooi" {
+		e.preeditor.ProcessKey(ch, bamboo.VietnameseMode)
+	}
+	if e.getRawKeyLen() == 0 {
+		t.Fatal("Buffer should not be empty before FocusOut")
+	}
+
+	e.FocusOut()
+
+	if e.getRawKeyLen() != 0 {
+		t.Errorf("After FocusOut() in PreeditIM, buffer should be cleared, got rawKeyLen=%d", e.getRawKeyLen())
+	}
+}
+
+func TestFocusOutPreservesBufferInBackspaceMode(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	for _, ch := range "tooi" {
+		e.preeditor.ProcessKey(ch, bamboo.VietnameseMode)
+	}
+	if e.getRawKeyLen() == 0 {
+		t.Fatal("Buffer should not be empty before FocusOut")
+	}
+
+	e.FocusOut()
+
+	if e.getRawKeyLen() == 0 {
+		t.Errorf("After FocusOut() in SurroundingTextIM, buffer should be preserved")
+	}
+}
+
+func TestFakeBackspaceResetAfterSendCycle(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	// Manually set a non-zero fake backspace counter
+	e.setFakeBackspace(5)
+	if e.getFakeBackspace() != 5 {
+		t.Fatalf("Expected fakeBackspace=5, got %d", e.getFakeBackspace())
+	}
+
+	// Reset should clear it
+	e.resetFakeBackspace()
+	if e.getFakeBackspace() != 0 {
+		t.Errorf("After resetFakeBackspace(), expected 0, got %d", e.getFakeBackspace())
+	}
+}
+
+func TestGetOffsetRunes(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	tests := []struct {
+		name      string
+		newText   string
+		oldText   string
+		wantRunes string
+		wantNBS   int
+	}{
+		{"same_text", "tôi", "tôi", "", 0},
+		{"append_char", "tôi ", "tôi", " ", 0},
+		{"replace_middle", "tối", "tôi", "ối", 2},
+		{"empty_old", "abc", "", "abc", 0},
+		{"empty_new", "", "abc", "", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRunes, gotNBS := e.getOffsetRunes(tt.newText, tt.oldText)
+			if string(gotRunes) != tt.wantRunes {
+				t.Errorf("getOffsetRunes(%q, %q) runes = %q, want %q", tt.newText, tt.oldText, string(gotRunes), tt.wantRunes)
+			}
+			if gotNBS != tt.wantNBS {
+				t.Errorf("getOffsetRunes(%q, %q) nBS = %d, want %d", tt.newText, tt.oldText, gotNBS, tt.wantNBS)
+			}
+		})
+	}
+}
+
+// TestConcurrentResetAndKeyPress exercises the data race between
+// Reset/FocusIn/FocusOut (D-Bus thread) and keyPressHandler (worker goroutine).
+// Run with: go test -race -run TestConcurrentResetAndKeyPress
+func TestConcurrentResetAndKeyPress(t *testing.T) {
+	fe := NewFakeEngine()
+	cfg := config.DefaultCfg()
+	cfg.DefaultInputMode = config.SurroundingTextIM
+	inputMethod := bamboo.ParseInputMethod(cfg.InputMethodDefinitions, cfg.InputMethod)
+	e := NewIbusBambooEngine("test", &cfg, fe, bamboo.NewEngine(inputMethod, cfg.Flags))
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Goroutine 1: simulate keyPressHandler mutations (worker thread)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			e.Lock()
+			e.preeditor.ProcessKey('a', bamboo.VietnameseMode)
+			_ = e.getPreeditString()
+			e.preeditor.Reset()
+			e.Unlock()
+		}
+	}()
+
+	// Goroutine 2: simulate Reset/FocusIn/FocusOut (D-Bus thread)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			switch i % 3 {
+			case 0:
+				e.Reset()
+			case 1:
+				e.FocusIn()
+			case 2:
+				e.FocusOut()
+			}
+		}
+	}()
+
+	wg.Wait()
+	// If we get here without a race detector complaint, the lock is working.
 }

--- a/engine_utils.go
+++ b/engine_utils.go
@@ -132,13 +132,27 @@ var sleep = func() {
 }
 
 func (e *IBusBambooEngine) resetBuffer() {
-	if e.getRawKeyLen() == 0 {
-		return
-	}
 	if e.checkInputMode(config.PreeditIM) {
-		e.commitPreeditAndReset(e.getPreeditString())
+		// commitPreeditAndReset makes D-Bus calls, so we read the
+		// preedit string under lock but call commitPreeditAndReset
+		// without it (commitPreeditAndReset resets the preeditor
+		// internally under its own flow). The empty-buffer guard must
+		// also run under the lock, otherwise it races with the worker
+		// goroutine mutating the preeditor.
+		e.Lock()
+		if e.getRawKeyLen() == 0 {
+			e.Unlock()
+			return
+		}
+		var preeditStr = e.getPreeditString()
+		e.Unlock()
+		e.commitPreeditAndReset(preeditStr)
 	} else {
-		e.preeditor.Reset()
+		e.Lock()
+		if e.getRawKeyLen() > 0 {
+			e.preeditor.Reset()
+		}
+		e.Unlock()
 	}
 }
 


### PR DESCRIPTION
## Problem

IBus dispatches each incoming D-Bus method on its own goroutine (`go conn.handleCall` in godbus). That means `Reset`, `FocusIn`, and `FocusOut` run concurrently with the `keyPressChan` worker goroutine (`keyPressCapturing`). Both paths mutate the shared `bamboo` preeditor, which is not safe for concurrent use — a data race that can corrupt the buffer and produce wrong output (e.g. `oof` → `ôf` instead of `ồ`, stale words after focus changes).

## Changes

- Guard preeditor mutations with the engine mutex in `FocusOut`, `Reset`, `bsProcessKeyEvent`, and `keyPressHandler`.
- `resetBuffer`: move the `getRawKeyLen()` empty-buffer guard **inside** the lock in both branches. It previously read the preeditor unlocked on the `FocusIn → checkWmClass → resetBuffer` path, racing the worker goroutine.
- `Reset`: drain `keyPressChan` with a non-blocking `select`/`default` loop instead of `len()>0` + `<-`. Other goroutines also receive from the channel, so the blocking form could hang the D-Bus thread on an empty channel (TOCTOU).
- `SendBackSpace`: clamp `n` to `[1, maxBackSpacePerCycle]` and reset the fake-backspace counter after each send cycle, so a dropped synthetic backspace can't leave a permanent offset.
- Discard the ephemeral preedit buffer on `Reset`/`FocusOut` in `PreeditIM` only; backspace modes preserve the buffer (apps call `Reset` aggressively mid-word).

## Testing

```
CGO_ENABLED=1 go test . -mod=vendor -race -run "TestReset|TestFocus|TestFakeBackspace|TestGetOffset|TestConcurrent" -v
```

- `TestConcurrentResetAndKeyPress` stresses Reset/FocusIn/FocusOut against the worker goroutine under `-race`.
- Buffer-semantics tests per input mode (PreeditIM clears, backspace modes preserve), `keyPressChan` drain, `getOffsetRunes`, and fake-backspace reset.
- Full suite passes clean under `-race`.